### PR TITLE
chore: Added nix flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1754214453,
+        "narHash": "sha256-Q/I2xJn/j1wpkGhWkQnm20nShYnG7TI99foDBpXm1SY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5b09dc45f24cf32316283e62aec81ffee3c3e376",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "A Nix flake for the development of NIddle.";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    flake-utils,
+    ...
+  } @ inputs:
+    flake-utils.lib.eachDefaultSystem (
+      system: let
+        pkgs = import nixpkgs {inherit system;};
+      in {
+        formatter = pkgs.alejandra;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            (pkgs.python312.withPackages (pypkgs:
+              with pypkgs; [
+                fastapi
+                uvicorn
+                ruff
+              ]))
+          ];
+
+          shellHook = ''
+            help() {
+              echo "dev                            Run the FastAPI app in development mode with auto-reload"
+              echo "lint                           Run linting and formatting checks with ruff"
+              echo "format                         Format code and fix linting issues with ruff"
+            }
+
+            dev() {
+              echo "Starting FastAPI development server..."
+              uvicorn main:app --reload --host 0.0.0.0 --port 8000
+            }
+
+            lint() {
+              echo "Running ruff linting and format checks..."
+              ruff check .
+              ruff format --check .
+              echo "Linting checks completed!"
+            }
+
+            format() {
+              echo "Formatting code and fixing linting issues..."
+              ruff check . --fix
+              ruff format .
+              echo "Code formatted successfully!"
+            }
+          '';
+        };
+      }
+    );
+}


### PR DESCRIPTION
This PR adds a Nix flake to provide a reproducible development environment, allowing Nix users to get started by simply running `nix develop`.

Available commands:

- `dev`: Run the FastAPI app in development mode with auto-reload
- `lint`: Run linting and formatting checks with ruff
- `format`: Format code and fix linting issues with ruff