### PR TITLE
fix: delete redundant calls to ValidationPipe & updated pipe opt.

### DIFF
--- a/apps/api/src/associations/associations.controller.ts
+++ b/apps/api/src/associations/associations.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
@@ -48,7 +47,7 @@ export class AssociationsController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
   create(
-    @Body(ValidationPipe) createAssociationDto: CreateAssociationDto,
+    @Body() createAssociationDto: CreateAssociationDto,
   ): Promise<Association> {
     return this.associationsService.create(createAssociationDto);
   }
@@ -63,7 +62,7 @@ export class AssociationsController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateAssociationDto: UpdateAssociationDto,
+    @Body() updateAssociationDto: UpdateAssociationDto,
   ): Promise<Association> {
     return this.associationsService.update(id, updateAssociationDto);
   }

--- a/apps/api/src/auth/auth.controller.ts
+++ b/apps/api/src/auth/auth.controller.ts
@@ -7,7 +7,6 @@ import {
   Request,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AuthService } from "./auth.service";
@@ -46,7 +45,7 @@ export class AuthController {
   })
   @UseGuards(LocalAuthGuard)
   @Post("login")
-  async signIn(@Body(ValidationPipe) signInDto: SignInDto) {
+  async signIn(@Body() signInDto: SignInDto) {
     return this.authService.signIn(signInDto);
   }
 }

--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
@@ -48,7 +47,7 @@ export class CoursesController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
   create(
-    @Body(ValidationPipe) createCourseDto: CreateCourseDto,
+    @Body() createCourseDto: CreateCourseDto,
   ): Promise<Course> {
     return this.coursesService.create(createCourseDto);
   }
@@ -63,7 +62,7 @@ export class CoursesController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateCourseDto: UpdateCourseDto,
+    @Body() updateCourseDto: UpdateCourseDto,
   ): Promise<Course> {
     return this.coursesService.update(id, updateCourseDto);
   }

--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -46,9 +46,7 @@ export class CoursesController {
   @ApiResponse({ status: 403, description: "Forbidden." })
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
-  create(
-    @Body() createCourseDto: CreateCourseDto,
-  ): Promise<Course> {
+  create(@Body() createCourseDto: CreateCourseDto): Promise<Course> {
     return this.coursesService.create(createCourseDto);
   }
 

--- a/apps/api/src/events/events.controller.ts
+++ b/apps/api/src/events/events.controller.ts
@@ -12,7 +12,6 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -62,7 +61,7 @@ export class EventsController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard, ActiveAssociationGuard)
   @Post()
   create(
-    @Body(ValidationPipe) createEventDto: CreateEventDto,
+    @Body() createEventDto: CreateEventDto,
     @Req() req: { activeAssociationId: number },
   ): Promise<Event> {
     return this.eventsService.create(createEventDto, req.activeAssociationId);
@@ -78,7 +77,7 @@ export class EventsController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateEventDto: UpdateEventDto,
+    @Body() updateEventDto: UpdateEventDto,
   ): Promise<Event> {
     return this.eventsService.update(id, updateEventDto);
   }

--- a/apps/api/src/faculties/faculties.controller.ts
+++ b/apps/api/src/faculties/faculties.controller.ts
@@ -46,9 +46,7 @@ export class FacultiesController {
   @ApiResponse({ status: 403, description: "Forbidden." })
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
-  create(
-    @Body() createFacultyDto: CreateFacultyDto,
-  ): Promise<Faculty> {
+  create(@Body() createFacultyDto: CreateFacultyDto): Promise<Faculty> {
     return this.facultiesService.create(createFacultyDto);
   }
 

--- a/apps/api/src/faculties/faculties.controller.ts
+++ b/apps/api/src/faculties/faculties.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
@@ -48,7 +47,7 @@ export class FacultiesController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
   create(
-    @Body(ValidationPipe) createFacultyDto: CreateFacultyDto,
+    @Body() createFacultyDto: CreateFacultyDto,
   ): Promise<Faculty> {
     return this.facultiesService.create(createFacultyDto);
   }
@@ -63,7 +62,7 @@ export class FacultiesController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateFacultyDto: UpdateFacultyDto,
+    @Body() updateFacultyDto: UpdateFacultyDto,
   ): Promise<Faculty> {
     return this.facultiesService.update(id, updateFacultyDto);
   }

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -4,10 +4,17 @@ import { ValidationPipe } from "@nestjs/common";
 import { NestFactory } from "@nestjs/core";
 import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
 import { AppModule } from "./app.module";
+import { EntityNotFoundFilter } from "./filters/entity-not-found.filter";
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
+
+  app.useGlobalPipes(new ValidationPipe({
+    whitelist: true,
+    forbidNonWhitelisted: true,
+    
+  }));
+  app.useGlobalFilters(new EntityNotFoundFilter());
 
   const port = process.env.PORT ?? 3001;
   const config = new DocumentBuilder()

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -9,11 +9,12 @@ import { EntityNotFoundFilter } from "./filters/entity-not-found.filter";
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
-  app.useGlobalPipes(new ValidationPipe({
-    whitelist: true,
-    forbidNonWhitelisted: true,
-    
-  }));
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      forbidNonWhitelisted: true,
+    }),
+  );
   app.useGlobalFilters(new EntityNotFoundFilter());
 
   const port = process.env.PORT ?? 3001;

--- a/apps/api/src/requests/requests.controller.ts
+++ b/apps/api/src/requests/requests.controller.ts
@@ -11,7 +11,6 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -95,7 +94,7 @@ export class RequestsController {
   @Post()
   @UseGuards(JwtAuthGuard, ActiveAssociationGuard)
   async create(
-    @Body(ValidationPipe) createRequestDto: CreateRequestDto,
+    @Body() createRequestDto: CreateRequestDto,
     @Req() req: { user: User; activeAssociationId: number },
   ): Promise<Request> {
     return this.requestsService.create(
@@ -119,7 +118,7 @@ export class RequestsController {
   @UseGuards(JwtAuthGuard, ActiveAssociationGuard)
   async update(
     @Param("id") id: string,
-    @Body(ValidationPipe) updateRequestDto: UpdateRequestDto,
+    @Body() updateRequestDto: UpdateRequestDto,
     @Req() req: { activeAssociationId: number },
   ): Promise<Request> {
     return this.requestsService.update(
@@ -148,7 +147,7 @@ export class RequestsController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   async reject(
     @Param("id") id: string,
-    @Body(ValidationPipe) rejectRequestDto: RejectRequestDto,
+    @Body() rejectRequestDto: RejectRequestDto,
   ): Promise<Request> {
     return this.requestsService.reject(id, rejectRequestDto);
   }

--- a/apps/api/src/services/dto/create-schedule.dto.spec.ts
+++ b/apps/api/src/services/dto/create-schedule.dto.spec.ts
@@ -1,0 +1,132 @@
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { EnumDays } from "@/services/entity/schedule.entity";
+import { CreateScheduleDto } from "./create-schedule.dto";
+
+describe("CreateScheduleDto validation", () => {
+  it("valid dto should have no validation errors", async () => {
+    const dto = new CreateScheduleDto();
+    dto.startTime = "09:00";
+    dto.endTime = "17:00";
+    dto.dayOfWeek = EnumDays.MONDAY;
+
+    const errors = await validate(dto);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  describe("startTime", () => {
+    it("should reject a missing startTime", async () => {
+      const dto = new CreateScheduleDto();
+      dto.endTime = "17:00";
+      dto.dayOfWeek = EnumDays.MONDAY;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "startTime")).toBe(true);
+    });
+
+    it("should reject a non-military-time startTime", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = "9am";
+      dto.endTime = "17:00";
+      dto.dayOfWeek = EnumDays.MONDAY;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "startTime")).toBe(true);
+    });
+
+    it("should reject a non-string startTime", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = 900 as any;
+      dto.endTime = "17:00";
+      dto.dayOfWeek = EnumDays.MONDAY;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "startTime")).toBe(true);
+    });
+  });
+
+  describe("endTime", () => {
+    it("should reject a missing endTime", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = "09:00";
+      dto.dayOfWeek = EnumDays.MONDAY;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "endTime")).toBe(true);
+    });
+
+    it("should reject a non-military-time endTime", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = "09:00";
+      dto.endTime = "25:99";
+      dto.dayOfWeek = EnumDays.MONDAY;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "endTime")).toBe(true);
+    });
+  });
+
+  describe("dayOfWeek", () => {
+    it("should reject a missing dayOfWeek", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = "09:00";
+      dto.endTime = "17:00";
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "dayOfWeek")).toBe(true);
+    });
+
+    it("should reject a dayOfWeek outside the EnumDays values", async () => {
+      const dto = new CreateScheduleDto();
+      dto.startTime = "09:00";
+      dto.endTime = "17:00";
+      dto.dayOfWeek = "Someday" as EnumDays;
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "dayOfWeek")).toBe(true);
+    });
+
+    it("should accept every EnumDays value", async () => {
+      for (const day of Object.values(EnumDays)) {
+        const dto = new CreateScheduleDto();
+        dto.startTime = "09:00";
+        dto.endTime = "17:00";
+        dto.dayOfWeek = day;
+
+        const errors = await validate(dto);
+
+        expect(errors).toHaveLength(0);
+      }
+    });
+  });
+
+  it("should transform a plain object into a CreateScheduleDto instance", () => {
+    const plain = { startTime: "09:00", endTime: "17:00", dayOfWeek: "Monday" };
+
+    const dto = plainToInstance(CreateScheduleDto, plain);
+
+    expect(dto).toBeInstanceOf(CreateScheduleDto);
+    expect(dto.startTime).toBe("09:00");
+    expect(dto.endTime).toBe("17:00");
+    expect(dto.dayOfWeek).toBe(EnumDays.MONDAY);
+  });
+
+  it("only carries the fields a client should send (no id/service)", () => {
+    const dto = plainToInstance(CreateScheduleDto, {
+      startTime: "09:00",
+      endTime: "17:00",
+      dayOfWeek: "Monday",
+    });
+
+    expect(dto).not.toHaveProperty("id");
+    expect(dto).not.toHaveProperty("service");
+  });
+});

--- a/apps/api/src/services/dto/create-schedule.dto.ts
+++ b/apps/api/src/services/dto/create-schedule.dto.ts
@@ -1,0 +1,30 @@
+import { IsEnum, IsMilitaryTime, IsNotEmpty, IsString } from "class-validator";
+import { EnumDays } from "@/services/entity/schedule.entity";
+
+export class CreateScheduleDto {
+  /**
+   * The start time of the schedule slot, in 24h format.
+   * @example '09:00'
+   */
+  @IsString()
+  @IsMilitaryTime()
+  @IsNotEmpty()
+  startTime: string;
+
+  /**
+   * The end time of the schedule slot, in 24h format.
+   * @example '17:00'
+   */
+  @IsString()
+  @IsMilitaryTime()
+  @IsNotEmpty()
+  endTime: string;
+
+  /**
+   * The day of the week this schedule slot applies to.
+   * @example 'Monday'
+   */
+  @IsEnum(EnumDays)
+  @IsNotEmpty()
+  dayOfWeek: EnumDays;
+}

--- a/apps/api/src/services/dto/create-service.dto.spec.ts
+++ b/apps/api/src/services/dto/create-service.dto.spec.ts
@@ -28,7 +28,7 @@ describe("CreateServiceDto validation", () => {
     expect(errors.some((e) => e.property === "name")).toBe(true);
   });
 
-  it("should transform plain schedule object into Schedule instance using Type decorator", () => {
+  it("should transform plain schedule object into CreateScheduleDto instance using Type decorator", () => {
     const plain = {
       name: "Papelaria",
       location: "B-142",

--- a/apps/api/src/services/dto/create-service.dto.ts
+++ b/apps/api/src/services/dto/create-service.dto.ts
@@ -7,7 +7,7 @@ import {
   IsString,
   ValidateNested,
 } from "class-validator";
-import { Schedule } from "@/services/entity/schedule.entity";
+import { CreateScheduleDto } from "@/services/dto/create-schedule.dto";
 
 export class CreateServiceDto {
   /**
@@ -41,8 +41,8 @@ export class CreateServiceDto {
    */
   @IsNotEmpty()
   @ValidateNested({ each: true })
-  @Type(() => Schedule)
-  schedule: Schedule[];
+  @Type(() => CreateScheduleDto)
+  schedule: CreateScheduleDto[];
 
   /**
    * The service's phone number.

--- a/apps/api/src/services/services.controller.ts
+++ b/apps/api/src/services/services.controller.ts
@@ -12,7 +12,6 @@ import {
   Req,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import {
   ApiBearerAuth,
@@ -62,7 +61,7 @@ export class ServicesController {
   @UseGuards(JwtAuthGuard, AdminOnlyGuard, ActiveAssociationGuard)
   @Post()
   create(
-    @Body(ValidationPipe) createServiceDto: CreateServiceDto,
+    @Body() createServiceDto: CreateServiceDto,
     @Req() req: { activeAssociationId: number },
   ): Promise<Service> {
     return this.servicesService.create(
@@ -81,7 +80,7 @@ export class ServicesController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateServiceDto: UpdateServiceDto,
+    @Body() updateServiceDto: UpdateServiceDto,
   ): Promise<Service> {
     return this.servicesService.update(id, updateServiceDto);
   }

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -10,7 +10,6 @@ import {
   Post,
   UseGuards,
   UseInterceptors,
-  ValidationPipe,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
@@ -39,7 +38,7 @@ export class UsersController {
   @ApiResponse({ status: 403, description: "Forbidden." })
   @UseGuards(JwtAuthGuard, AdminOnlyGuard)
   @Post()
-  create(@Body(ValidationPipe) createUserDto: CreateUserDto): Promise<User> {
+  create(@Body() createUserDto: CreateUserDto): Promise<User> {
     return this.usersService.create(createUserDto);
   }
 
@@ -61,7 +60,7 @@ export class UsersController {
   @Patch(":id")
   update(
     @Param("id", ParseIntPipe) id: number,
-    @Body(ValidationPipe) updateUserDto: UpdateUserDto,
+    @Body() updateUserDto: UpdateUserDto,
   ): Promise<User> {
     return this.usersService.update(id, updateUserDto);
   }


### PR DESCRIPTION
## Motive

Previously the `ValidationPipe` provided by Nest to validate the received objects from the client was declared as a global pipe in `main.ts` and also in each `@Body()` decorator in each route where the validation was needed.

This is a clear redundancy as the declaration of `ValidationPipe` as global makes it run the validation in every route (every `@Body(), @Query(), @Param()` ) that has its type as a Dto with `class-validators` automatically.

## Extra addictions

I added two properties to the global `ValidationPipe`:
- `whitelist` - which ignores every extra field that the user sends that its not marked in the dto 
- `forbidNonWhitelisted` - which automatically launches a 400 error when the client provides extra fields that are not declared in the dto with class-validators

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added schedule creation validation for time formats and days of the week.
  * Service creation now accepts validated schedule details.

* **Bug Fixes**
  * Standardized request validation across API endpoints.
  * Invalid or unexpected request properties are now rejected.
  * Added consistent handling for missing entities.

* **Tests**
  * Added comprehensive coverage for schedule validation, transformation, required fields, and excluded properties.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->