### PR TITLE
feat: pagination & order filters

### DIFF
--- a/apps/api/src/associations/associations.controller.spec.ts
+++ b/apps/api/src/associations/associations.controller.spec.ts
@@ -58,9 +58,9 @@ describe("AssociationsController", () => {
     const expected = [{ id: "1", name: "Chess Club", acronym: "CC" }];
     service.findAll.mockResolvedValue(expected);
 
-    const result = await controller.findAll();
+    const result = await controller.findAll({ page: 1, limit: 10 });
 
-    expect(service.findAll).toHaveBeenCalled();
+    expect(service.findAll).toHaveBeenCalledWith({ page: 1, limit: 10 });
     expect(result).toBe(expected);
   });
 

--- a/apps/api/src/associations/associations.controller.ts
+++ b/apps/api/src/associations/associations.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
@@ -18,6 +19,7 @@ import { AssociationsService } from "./associations.service";
 import { CreateAssociationDto } from "./dto/create-association.dto";
 import { UpdateAssociationDto } from "./dto/update-association.dto";
 import { Association } from "./entities/association.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("associations")
@@ -27,8 +29,8 @@ export class AssociationsController {
   @ApiOperation({ summary: "Get all associations" })
   @ApiResponse({ status: 200, description: "List of associations returned." })
   @Get()
-  findAll(): Promise<Association[]> {
-    return this.associationsService.findAll();
+  findAll(@Query() pagination: PaginationDto): Promise<Association[]> {
+    return this.associationsService.findAll(pagination);
   }
 
   @ApiOperation({ summary: "Get association by UUID" })

--- a/apps/api/src/associations/associations.controller.ts
+++ b/apps/api/src/associations/associations.controller.ts
@@ -15,11 +15,11 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
 import { JwtAuthGuard } from "@/auth/guards/jwt-auth.guard";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { AssociationsService } from "./associations.service";
 import { CreateAssociationDto } from "./dto/create-association.dto";
 import { UpdateAssociationDto } from "./dto/update-association.dto";
 import { Association } from "./entities/association.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("associations")

--- a/apps/api/src/associations/associations.service.spec.ts
+++ b/apps/api/src/associations/associations.service.spec.ts
@@ -32,7 +32,7 @@ describe("AssociationsService", () => {
   const mockAssociationRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
     merge: jest.fn(),
@@ -83,13 +83,18 @@ describe("AssociationsService", () => {
 
   describe("findAll", () => {
     it("should return an array of associations", async () => {
-      mockAssociationRepository.find.mockResolvedValue([mockAssociation]);
+      mockAssociationRepository.findAndCount.mockResolvedValue([
+        [mockAssociation],
+        1,
+      ]);
 
-      const result = await service.findAll();
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual([mockAssociation]);
-      expect(mockAssociationRepository.find).toHaveBeenCalledWith({
+      expect(mockAssociationRepository.findAndCount).toHaveBeenCalledWith({
         relations: ["users"],
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/associations/associations.service.spec.ts
+++ b/apps/api/src/associations/associations.service.spec.ts
@@ -95,6 +95,7 @@ describe("AssociationsService", () => {
         relations: ["users"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/associations/associations.service.ts
+++ b/apps/api/src/associations/associations.service.ts
@@ -1,10 +1,10 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { CreateAssociationDto } from "./dto/create-association.dto";
 import { UpdateAssociationDto } from "./dto/update-association.dto";
 import { Association } from "./entities/association.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class AssociationsService {

--- a/apps/api/src/associations/associations.service.ts
+++ b/apps/api/src/associations/associations.service.ts
@@ -28,6 +28,7 @@ export class AssociationsService {
       relations: ["users"],
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/associations/associations.service.ts
+++ b/apps/api/src/associations/associations.service.ts
@@ -4,6 +4,7 @@ import { Repository } from "typeorm";
 import { CreateAssociationDto } from "./dto/create-association.dto";
 import { UpdateAssociationDto } from "./dto/update-association.dto";
 import { Association } from "./entities/association.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class AssociationsService {
@@ -20,10 +21,16 @@ export class AssociationsService {
     return this.associationRepository.save(association);
   }
 
-  findAll(): Promise<Association[]> {
-    return this.associationRepository.find({
+  async findAll(pagination: PaginationDto): Promise<Association[]> {
+    const { page, limit } = pagination;
+
+    const [items] = await this.associationRepository.findAndCount({
       relations: ["users"],
+      skip: (page - 1) * limit,
+      take: limit,
     });
+
+    return items;
   }
 
   findOne(id: string): Promise<Association> {

--- a/apps/api/src/common/dto/pagination.dto.spec.ts
+++ b/apps/api/src/common/dto/pagination.dto.spec.ts
@@ -1,0 +1,84 @@
+import "reflect-metadata";
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { PaginationDto } from "./pagination.dto";
+
+describe("PaginationDto", () => {
+  describe("defaults", () => {
+    it("defaults page to 1 and limit to 10 when not provided", () => {
+      const dto = plainToInstance(PaginationDto, {});
+
+      expect(dto.page).toBe(1);
+      expect(dto.limit).toBe(10);
+    });
+
+    it("is valid when no values are provided", async () => {
+      const dto = plainToInstance(PaginationDto, {});
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+  });
+
+  describe("transformation", () => {
+    it("converts numeric strings to numbers via @Type", () => {
+      const dto = plainToInstance(PaginationDto, { page: "2", limit: "20" });
+
+      expect(dto.page).toBe(2);
+      expect(dto.limit).toBe(20);
+      expect(typeof dto.page).toBe("number");
+      expect(typeof dto.limit).toBe("number");
+    });
+  });
+
+  describe("validation", () => {
+    it("is valid with page and limit within range", async () => {
+      const dto = plainToInstance(PaginationDto, { page: 3, limit: 50 });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("rejects a page below 1", async () => {
+      const dto = plainToInstance(PaginationDto, { page: 0 });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "page")).toBe(true);
+    });
+
+    it("rejects a non-integer page", async () => {
+      const dto = plainToInstance(PaginationDto, { page: 1.5 });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "page")).toBe(true);
+    });
+
+    it("rejects a limit below 1", async () => {
+      const dto = plainToInstance(PaginationDto, { limit: 0 });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "limit")).toBe(true);
+    });
+
+    it("rejects a limit above 100", async () => {
+      const dto = plainToInstance(PaginationDto, { limit: 101 });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "limit")).toBe(true);
+    });
+
+    it("rejects a non-integer limit", async () => {
+      const dto = plainToInstance(PaginationDto, { limit: 10.5 });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "limit")).toBe(true);
+    });
+  });
+});

--- a/apps/api/src/common/dto/pagination.dto.ts
+++ b/apps/api/src/common/dto/pagination.dto.ts
@@ -1,0 +1,17 @@
+import { Type } from "class-transformer";
+import { IsInt, IsOptional, Max, Min } from "class-validator";
+
+export class PaginationDto {
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Type(() => Number)
+    page: number = 1;
+
+    @IsOptional()
+    @IsInt()
+    @Min(1)
+    @Max(100)
+    @Type(() => Number)
+    limit: number = 10;
+}

--- a/apps/api/src/common/dto/pagination.dto.ts
+++ b/apps/api/src/common/dto/pagination.dto.ts
@@ -1,17 +1,28 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
 import { Type } from "class-transformer";
 import { IsInt, IsOptional, Max, Min } from "class-validator";
 
 export class PaginationDto {
-    @IsOptional()
-    @IsInt()
-    @Min(1)
-    @Type(() => Number)
-    page: number = 1;
+  /**
+   * The page of the data we want to search'
+   * @example 2
+   */
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Type(() => Number)
+  page: number = 1;
 
-    @IsOptional()
-    @IsInt()
-    @Min(1)
-    @Max(100)
-    @Type(() => Number)
-    limit: number = 10;
+  /**
+   * The number of rows to be returned per page
+   * @example 10
+   */
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(100)
+  @Type(() => Number)
+  limit: number = 10;
 }

--- a/apps/api/src/courses/courses.controller.spec.ts
+++ b/apps/api/src/courses/courses.controller.spec.ts
@@ -52,10 +52,13 @@ describe("CoursesController", () => {
       const courses = [mockCourse];
       mockCoursesService.findAll.mockResolvedValue(courses);
 
-      const result = await controller.findAll();
+      const result = await controller.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(courses);
-      expect(mockCoursesService.findAll).toHaveBeenCalled();
+      expect(mockCoursesService.findAll).toHaveBeenCalledWith({
+        page: 1,
+        limit: 10,
+      });
     });
   });
 

--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
@@ -18,6 +19,7 @@ import { CoursesService } from "./courses.service";
 import { CreateCourseDto } from "./dto/create-course.dto";
 import { UpdateCourseDto } from "./dto/update-course.dto";
 import { Course } from "./entities/course.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("courses")
@@ -27,8 +29,8 @@ export class CoursesController {
   @ApiOperation({ summary: "Get all courses" })
   @ApiResponse({ status: 200, description: "List of courses returned." })
   @Get()
-  findAll(): Promise<Course[]> {
-    return this.coursesService.findAll();
+  findAll(@Query() pagination: PaginationDto): Promise<Course[]> {
+    return this.coursesService.findAll(pagination);
   }
 
   @ApiOperation({ summary: "Get course by UUID" })

--- a/apps/api/src/courses/courses.controller.ts
+++ b/apps/api/src/courses/courses.controller.ts
@@ -15,11 +15,11 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
 import { JwtAuthGuard } from "@/auth/guards/jwt-auth.guard";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { CoursesService } from "./courses.service";
 import { CreateCourseDto } from "./dto/create-course.dto";
 import { UpdateCourseDto } from "./dto/update-course.dto";
 import { Course } from "./entities/course.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("courses")

--- a/apps/api/src/courses/courses.service.spec.ts
+++ b/apps/api/src/courses/courses.service.spec.ts
@@ -82,6 +82,7 @@ describe("CoursesService", () => {
         relations: ["faculties"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/courses/courses.service.spec.ts
+++ b/apps/api/src/courses/courses.service.spec.ts
@@ -29,7 +29,7 @@ describe("CoursesService", () => {
   const mockCourseRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneBy: jest.fn(),
     merge: jest.fn(),
@@ -70,13 +70,18 @@ describe("CoursesService", () => {
   describe("findAll", () => {
     it("should return an array of courses", async () => {
       const courses = [mockCourse];
-      mockCourseRepository.find.mockResolvedValue(courses);
+      mockCourseRepository.findAndCount.mockResolvedValue([
+        courses,
+        courses.length,
+      ]);
 
-      const result = await service.findAll();
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(courses);
-      expect(mockCourseRepository.find).toHaveBeenCalledWith({
+      expect(mockCourseRepository.findAndCount).toHaveBeenCalledWith({
         relations: ["faculties"],
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/courses/courses.service.ts
+++ b/apps/api/src/courses/courses.service.ts
@@ -39,6 +39,7 @@ export class CoursesService {
       relations: ["faculties"],
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/courses/courses.service.ts
+++ b/apps/api/src/courses/courses.service.ts
@@ -6,6 +6,7 @@ import { Faculty } from "@/faculties/entities/faculty.entity";
 import { CreateCourseDto } from "./dto/create-course.dto";
 import { UpdateCourseDto } from "./dto/update-course.dto";
 import { Course } from "./entities/course.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class CoursesService {
@@ -31,8 +32,16 @@ export class CoursesService {
     return this.courseRepository.save(course);
   }
 
-  findAll(): Promise<Course[]> {
-    return this.courseRepository.find({ relations: ["faculties"] });
+  async findAll(pagination: PaginationDto): Promise<Course[]> {
+    const { page, limit } = pagination;
+
+    const [items] = await this.courseRepository.findAndCount({
+       relations: ["faculties"],
+       skip: (page - 1) * limit,
+       take: limit, 
+      });
+
+    return items;
   }
 
   findOne(id: string): Promise<Course> {

--- a/apps/api/src/courses/courses.service.ts
+++ b/apps/api/src/courses/courses.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { validateAndGetRelations } from "@/common/utils/entity-relation.utils";
 import { Faculty } from "@/faculties/entities/faculty.entity";
 import { CreateCourseDto } from "./dto/create-course.dto";
 import { UpdateCourseDto } from "./dto/update-course.dto";
 import { Course } from "./entities/course.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class CoursesService {
@@ -36,10 +36,10 @@ export class CoursesService {
     const { page, limit } = pagination;
 
     const [items] = await this.courseRepository.findAndCount({
-       relations: ["faculties"],
-       skip: (page - 1) * limit,
-       take: limit, 
-      });
+      relations: ["faculties"],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
 
     return items;
   }

--- a/apps/api/src/database/database.service.spec.ts
+++ b/apps/api/src/database/database.service.spec.ts
@@ -132,6 +132,20 @@ describe("DatabaseService", () => {
     process.env.NODE_ENV = originalEnv;
   });
 
+  it("should default to port 5432 when DATABASE_PORT is not set", () => {
+    const originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = "development";
+    delete process.env.DATABASE_PORT;
+
+    const options = service.createTypeOrmOptions();
+    expect(
+      (options as { replication: { master: { port: number } } }).replication
+        .master.port,
+    ).toBe(5432);
+
+    process.env.NODE_ENV = originalEnv;
+  });
+
   it("should create a single-host connection with custom port when DATABASE_SLAVE is not set", () => {
     const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";

--- a/apps/api/src/database/database.service.spec.ts
+++ b/apps/api/src/database/database.service.spec.ts
@@ -8,6 +8,10 @@ describe("DatabaseService", () => {
   let mockDataSource: Partial<DataSource>;
   let module: TestingModule;
 
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  const ORIGINAL_DATABASE_PORT = process.env.DATABASE_PORT;
+  const ORIGINAL_DATABASE_SYNCHRONIZE = process.env.DATABASE_SYNCHRONIZE;
+
   beforeEach(async () => {
     process.env.DATABASE_MASTER = "test-master";
     process.env.DATABASE_SLAVE = "test-slave";
@@ -39,6 +43,25 @@ describe("DatabaseService", () => {
     delete process.env.DATABASE_USER;
     delete process.env.DATABASE_PASSWORD;
     delete process.env.DATABASE_NAME;
+
+    if (ORIGINAL_NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    }
+
+    if (ORIGINAL_DATABASE_PORT === undefined) {
+      delete process.env.DATABASE_PORT;
+    } else {
+      process.env.DATABASE_PORT = ORIGINAL_DATABASE_PORT;
+    }
+
+    if (ORIGINAL_DATABASE_SYNCHRONIZE === undefined) {
+      delete process.env.DATABASE_SYNCHRONIZE;
+    } else {
+      process.env.DATABASE_SYNCHRONIZE = ORIGINAL_DATABASE_SYNCHRONIZE;
+    }
+
     await module.close();
   });
 
@@ -47,18 +70,14 @@ describe("DatabaseService", () => {
   });
 
   it("should create typeorm options for test", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "test";
 
     const options = service.createTypeOrmOptions();
     expect(options.type).toBe("sqlite");
     expect(options.database).toBe(":memory:");
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should create typeorm options for development", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
 
     const options = service.createTypeOrmOptions();
@@ -68,12 +87,9 @@ describe("DatabaseService", () => {
         .master.database,
     ).toBe("test-db");
     expect(options.synchronize).toBe(true);
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should create a single-host connection when DATABASE_SLAVE is not set", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     delete process.env.DATABASE_SLAVE;
 
@@ -82,26 +98,17 @@ describe("DatabaseService", () => {
     expect(options).not.toHaveProperty("replication");
     expect((options as { host: string }).host).toBe("test-master");
     expect((options as { database: string }).database).toBe("test-db");
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should allow synchronize override in production", () => {
-    const originalEnv = process.env.NODE_ENV;
-    const originalSynchronize = process.env.DATABASE_SYNCHRONIZE;
     process.env.NODE_ENV = "production";
     process.env.DATABASE_SYNCHRONIZE = "true";
 
     const options = service.createTypeOrmOptions();
     expect(options.synchronize).toBe(true);
-
-    process.env.NODE_ENV = originalEnv;
-    process.env.DATABASE_SYNCHRONIZE = originalSynchronize;
   });
 
   it("should create typeorm options for production", () => {
-    const originalEnv = process.env.NODE_ENV;
-    const originalSynchronize = process.env.DATABASE_SYNCHRONIZE;
     process.env.NODE_ENV = "production";
     delete process.env.DATABASE_SYNCHRONIZE;
 
@@ -112,13 +119,9 @@ describe("DatabaseService", () => {
         .master.database,
     ).toBe("test-db");
     expect(options.synchronize).toBe(false);
-
-    process.env.NODE_ENV = originalEnv;
-    process.env.DATABASE_SYNCHRONIZE = originalSynchronize;
   });
 
   it("should use custom DATABASE_PORT when provided", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     process.env.DATABASE_PORT = "5433";
 
@@ -127,13 +130,9 @@ describe("DatabaseService", () => {
       (options as { replication: { master: { port: number } } }).replication
         .master.port,
     ).toBe(5433);
-
-    delete process.env.DATABASE_PORT;
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should default to port 5432 when DATABASE_PORT is not set", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     delete process.env.DATABASE_PORT;
 
@@ -142,12 +141,9 @@ describe("DatabaseService", () => {
       (options as { replication: { master: { port: number } } }).replication
         .master.port,
     ).toBe(5432);
-
-    process.env.NODE_ENV = originalEnv;
   });
 
   it("should create a single-host connection with custom port when DATABASE_SLAVE is not set", () => {
-    const originalEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = "development";
     process.env.DATABASE_PORT = "5433";
     delete process.env.DATABASE_SLAVE;
@@ -155,8 +151,5 @@ describe("DatabaseService", () => {
     const options = service.createTypeOrmOptions();
     expect(options.type).toBe("postgres");
     expect((options as { port: number }).port).toBe(5433);
-
-    delete process.env.DATABASE_PORT;
-    process.env.NODE_ENV = originalEnv;
   });
 });

--- a/apps/api/src/database/schema.spec.ts
+++ b/apps/api/src/database/schema.spec.ts
@@ -88,6 +88,20 @@ describe("createSchema", () => {
     delete process.env.DATABASE_PORT;
   });
 
+  it("should default to port 5432 when DATABASE_PORT is not set", async () => {
+    process.env.NODE_ENV = "development";
+    delete process.env.DATABASE_PORT;
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+
+    await createSchema();
+
+    expect(DataSource).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 5432 }),
+    );
+
+    logSpy.mockRestore();
+  });
+
   it("should handle schema creation failure", async () => {
     const originalDataSource = DataSource;
     (DataSource as unknown as jest.Mock).mockImplementationOnce((options) => {

--- a/apps/api/src/database/schema.spec.ts
+++ b/apps/api/src/database/schema.spec.ts
@@ -33,6 +33,7 @@ describe("createSchema", () => {
   });
   afterEach(() => {
     process.env = OLD_ENV;
+    jest.restoreAllMocks();
     jest.clearAllMocks();
   });
 
@@ -44,7 +45,6 @@ describe("createSchema", () => {
     expect(logSpy).toHaveBeenCalledWith(
       "Database schema created successfully.",
     );
-    logSpy.mockRestore();
   });
 
   it("should log when schema sync is disabled in production", async () => {
@@ -55,7 +55,6 @@ describe("createSchema", () => {
     expect(logSpy).toHaveBeenCalledWith(
       "Database connection initialized; schema synchronization is disabled (set DATABASE_SYNCHRONIZE=true to enable it).",
     );
-    logSpy.mockRestore();
   });
 
   it("should enable schema sync when override is set in production", async () => {
@@ -69,8 +68,6 @@ describe("createSchema", () => {
     expect(logSpy).toHaveBeenCalledWith(
       "Database schema created successfully.",
     );
-
-    logSpy.mockRestore();
   });
 
   it("should use custom DATABASE_PORT when provided", async () => {
@@ -83,9 +80,7 @@ describe("createSchema", () => {
     expect(DataSource).toHaveBeenCalledWith(
       expect.objectContaining({ port: 5433 }),
     );
-
-    logSpy.mockRestore();
-    delete process.env.DATABASE_PORT;
+    expect(logSpy).toHaveBeenCalled();
   });
 
   it("should default to port 5432 when DATABASE_PORT is not set", async () => {
@@ -98,8 +93,7 @@ describe("createSchema", () => {
     expect(DataSource).toHaveBeenCalledWith(
       expect.objectContaining({ port: 5432 }),
     );
-
-    logSpy.mockRestore();
+    expect(logSpy).toHaveBeenCalled();
   });
 
   it("should handle schema creation failure", async () => {
@@ -126,8 +120,7 @@ describe("createSchema", () => {
       expect.stringContaining("Schema creation failed:"),
     );
     expect(errorSpy.mock.calls[0][1]).toBeInstanceOf(Error);
-    errorSpy.mockRestore();
-    exitSpy.mockRestore();
+    expect(exitSpy).not.toHaveBeenCalled();
   });
 
   describe("environment loading", () => {

--- a/apps/api/src/database/seed.spec.ts
+++ b/apps/api/src/database/seed.spec.ts
@@ -73,6 +73,16 @@ describe("Seed Script", () => {
     delete process.env.DATABASE_PORT;
   });
 
+  it("should default to port 5432 when DATABASE_PORT is not set", async () => {
+    delete process.env.DATABASE_PORT;
+
+    await seed();
+
+    expect(DataSource).toHaveBeenCalledWith(
+      expect.objectContaining({ port: 5432 }),
+    );
+  });
+
   describe("environment loading", () => {
     afterEach(() => {
       jest.resetModules();

--- a/apps/api/src/database/seed.spec.ts
+++ b/apps/api/src/database/seed.spec.ts
@@ -69,8 +69,6 @@ describe("Seed Script", () => {
     expect(DataSource).toHaveBeenCalledWith(
       expect.objectContaining({ port: 5433 }),
     );
-
-    delete process.env.DATABASE_PORT;
   });
 
   it("should default to port 5432 when DATABASE_PORT is not set", async () => {

--- a/apps/api/src/events/dto/event-filter.dto.spec.ts
+++ b/apps/api/src/events/dto/event-filter.dto.spec.ts
@@ -1,5 +1,6 @@
 import "reflect-metadata";
 import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
 import { EventFilterDto } from "./event-filter.dto";
 
 describe("EventFilterDto", () => {
@@ -26,5 +27,54 @@ describe("EventFilterDto", () => {
     expect(inst.year).toBeUndefined();
     expect(inst.facultyId).toBeUndefined();
     expect(inst.courseId).toBeUndefined();
+    expect(inst.sortBy).toBeUndefined();
+    expect(inst.sortOrder).toBeUndefined();
+  });
+
+  describe("sortBy / sortOrder", () => {
+    it.each([
+      "name",
+      "year",
+      "startDate",
+    ])("accepts %s as a valid sortBy value", async (sortBy) => {
+      const dto = plainToInstance(EventFilterDto, { sortBy });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("rejects a sortBy value that isn't whitelisted", async () => {
+      const dto = plainToInstance(EventFilterDto, { sortBy: "description" });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortBy")).toBe(true);
+    });
+
+    it.each([
+      "ASC",
+      "DESC",
+    ])("accepts %s as a valid sortOrder", async (sortOrder) => {
+      const dto = plainToInstance(EventFilterDto, {
+        sortBy: "name",
+        sortOrder,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("rejects an invalid sortOrder value", async () => {
+      const dto = plainToInstance(EventFilterDto, {
+        sortBy: "name",
+        sortOrder: "sideways",
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortOrder")).toBe(true);
+    });
   });
 });

--- a/apps/api/src/events/dto/event-filter.dto.ts
+++ b/apps/api/src/events/dto/event-filter.dto.ts
@@ -1,6 +1,6 @@
-import { PaginationDto } from "@/common/dto/pagination.dto";
 import { Type } from "class-transformer";
 import { IsOptional, IsUUID } from "class-validator";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 export class EventFilterDto extends PaginationDto {
   /**

--- a/apps/api/src/events/dto/event-filter.dto.ts
+++ b/apps/api/src/events/dto/event-filter.dto.ts
@@ -1,5 +1,5 @@
 import { Type } from "class-transformer";
-import { IsOptional, IsUUID } from "class-validator";
+import { IsIn, IsOptional, IsUUID } from "class-validator";
 import { PaginationDto } from "@/common/dto/pagination.dto";
 
 export class EventFilterDto extends PaginationDto {
@@ -26,4 +26,12 @@ export class EventFilterDto extends PaginationDto {
   @IsOptional()
   @IsUUID()
   courseId?: string;
+
+  @IsOptional()
+  @IsIn(["name", "year", "startDate"])
+  sortBy?: string;
+
+  @IsOptional()
+  @IsIn(["ASC", "DESC"])
+  sortOrder?: "ASC" | "DESC";
 }

--- a/apps/api/src/events/dto/event-filter.dto.ts
+++ b/apps/api/src/events/dto/event-filter.dto.ts
@@ -1,7 +1,8 @@
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { Type } from "class-transformer";
 import { IsOptional, IsUUID } from "class-validator";
 
-export class EventFilterDto {
+export class EventFilterDto extends PaginationDto {
   /**
    * The year to filter events by.
    * @example 2025

--- a/apps/api/src/events/events.controller.spec.ts
+++ b/apps/api/src/events/events.controller.spec.ts
@@ -86,7 +86,7 @@ describe("EventsController", () => {
   describe("findAll", () => {
     it("should return an array of events", async () => {
       const events = [mockEvent];
-      const filters: EventFilterDto = {};
+      const filters: EventFilterDto = { page: 1, limit: 10 };
       mockEventsService.findAll.mockResolvedValue(events);
 
       const result = await controller.findAll(filters);

--- a/apps/api/src/events/events.service.spec.ts
+++ b/apps/api/src/events/events.service.spec.ts
@@ -126,6 +126,7 @@ describe("EventsService", () => {
         relations: ["faculty", "courses", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -145,6 +146,7 @@ describe("EventsService", () => {
         relations: ["faculty", "courses", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -164,6 +166,7 @@ describe("EventsService", () => {
         relations: ["faculty", "courses", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -183,6 +186,7 @@ describe("EventsService", () => {
         relations: ["faculty", "courses", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/events/events.service.spec.ts
+++ b/apps/api/src/events/events.service.spec.ts
@@ -189,6 +189,47 @@ describe("EventsService", () => {
         order: { id: "ASC" },
       });
     });
+
+    it("orders by the requested sortBy field before the id tiebreaker", async () => {
+      const events = [mockEvent];
+      const filters: EventFilterDto = {
+        sortBy: "year",
+        sortOrder: "DESC",
+        page: 1,
+        limit: 10,
+      };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
+
+      await service.findAll(filters);
+
+      const { order } = mockEventRepository.findAndCount.mock.calls[0][0];
+      expect(order).toEqual({ year: "DESC", id: "ASC" });
+      // Key order matters: TypeORM builds ORDER BY in object-key insertion
+      // order, so the requested field must come before the id tiebreaker.
+      expect(Object.keys(order)).toEqual(["year", "id"]);
+    });
+
+    it("defaults sortOrder to ASC when only sortBy is provided", async () => {
+      const events = [mockEvent];
+      const filters: EventFilterDto = {
+        sortBy: "name",
+        page: 1,
+        limit: 10,
+      };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
+
+      await service.findAll(filters);
+
+      expect(mockEventRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ order: { name: "ASC", id: "ASC" } }),
+      );
+    });
   });
 
   describe("findOne", () => {

--- a/apps/api/src/events/events.service.spec.ts
+++ b/apps/api/src/events/events.service.spec.ts
@@ -52,7 +52,7 @@ describe("EventsService", () => {
   const mockEventRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
     merge: jest.fn(),
@@ -112,57 +112,77 @@ describe("EventsService", () => {
   describe("findAll", () => {
     it("should return an array of events without filters", async () => {
       const events = [mockEvent];
-      const filters: EventFilterDto = {};
-      mockEventRepository.find.mockResolvedValue(events);
+      const filters: EventFilterDto = { page: 1, limit: 10 };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
 
       const result = await service.findAll(filters);
 
       expect(result).toEqual(events);
-      expect(mockEventRepository.find).toHaveBeenCalledWith({
+      expect(mockEventRepository.findAndCount).toHaveBeenCalledWith({
         where: {},
         relations: ["faculty", "courses", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should return events filtered by year", async () => {
       const events = [mockEvent];
-      const filters: EventFilterDto = { year: 2025 };
-      mockEventRepository.find.mockResolvedValue(events);
+      const filters: EventFilterDto = { year: 2025, page: 1, limit: 10 };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
 
       const result = await service.findAll(filters);
 
       expect(result).toEqual(events);
-      expect(mockEventRepository.find).toHaveBeenCalledWith({
+      expect(mockEventRepository.findAndCount).toHaveBeenCalledWith({
         where: { year: 2025 },
         relations: ["faculty", "courses", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should return events filtered by facultyId", async () => {
       const events = [mockEvent];
-      const filters: EventFilterDto = { facultyId: "1" };
-      mockEventRepository.find.mockResolvedValue(events);
+      const filters: EventFilterDto = { facultyId: "1", page: 1, limit: 10 };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
 
       const result = await service.findAll(filters);
 
       expect(result).toEqual(events);
-      expect(mockEventRepository.find).toHaveBeenCalledWith({
+      expect(mockEventRepository.findAndCount).toHaveBeenCalledWith({
         where: { faculty: { id: "1" } },
         relations: ["faculty", "courses", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should return events filtered by courseId", async () => {
       const events = [mockEvent];
-      const filters: EventFilterDto = { courseId: "1" };
-      mockEventRepository.find.mockResolvedValue(events);
+      const filters: EventFilterDto = { courseId: "1", page: 1, limit: 10 };
+      mockEventRepository.findAndCount.mockResolvedValue([
+        events,
+        events.length,
+      ]);
 
       const result = await service.findAll(filters);
 
       expect(result).toEqual(events);
-      expect(mockEventRepository.find).toHaveBeenCalledWith({
+      expect(mockEventRepository.findAndCount).toHaveBeenCalledWith({
         where: { courses: { id: "1" } },
         relations: ["faculty", "courses", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -96,17 +96,21 @@ export class EventsService
     return this.update(id, payload);
   }
 
-  findAll(filters: EventFilterDto): Promise<Event[]> {
-    const { year, facultyId, courseId } = filters;
+  async findAll(filters: EventFilterDto): Promise<Event[]> {
+    const { year, facultyId, courseId, limit, page } = filters;
 
-    return this.eventRepository.find({
+    const [items] =  await this.eventRepository.findAndCount({
       where: {
         ...(year !== undefined && { year }),
         ...(facultyId && { faculty: { id: facultyId } }),
         ...(courseId && { courses: { id: courseId } }),
       },
       relations: ["faculty", "courses", "createdBy"],
+      skip: (page - 1) * limit,
+      take: limit,
     });
+
+    return items;
   }
 
   findOne(id: string): Promise<Event> {

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -108,6 +108,7 @@ export class EventsService
       relations: ["faculty", "courses", "createdBy"],
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -97,7 +97,8 @@ export class EventsService
   }
 
   async findAll(filters: EventFilterDto): Promise<Event[]> {
-    const { year, facultyId, courseId, limit, page } = filters;
+    const { year, facultyId, courseId, sortBy, sortOrder, limit, page } =
+      filters;
 
     const [items] = await this.eventRepository.findAndCount({
       where: {
@@ -108,7 +109,10 @@ export class EventsService
       relations: ["faculty", "courses", "createdBy"],
       skip: (page - 1) * limit,
       take: limit,
-      order: { id: "ASC" },
+      order: {
+        ...(sortBy && { [sortBy]: sortOrder ?? "ASC" }),
+        id: "ASC",
+      },
     });
 
     return items;

--- a/apps/api/src/events/events.service.ts
+++ b/apps/api/src/events/events.service.ts
@@ -99,7 +99,7 @@ export class EventsService
   async findAll(filters: EventFilterDto): Promise<Event[]> {
     const { year, facultyId, courseId, limit, page } = filters;
 
-    const [items] =  await this.eventRepository.findAndCount({
+    const [items] = await this.eventRepository.findAndCount({
       where: {
         ...(year !== undefined && { year }),
         ...(facultyId && { faculty: { id: facultyId } }),

--- a/apps/api/src/faculties/faculties.controller.spec.ts
+++ b/apps/api/src/faculties/faculties.controller.spec.ts
@@ -52,10 +52,13 @@ describe("FacultiesController", () => {
       const faculties = [mockFaculty];
       mockFacultiesService.findAll.mockResolvedValue(faculties);
 
-      const result = await controller.findAll();
+      const result = await controller.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(faculties);
-      expect(mockFacultiesService.findAll).toHaveBeenCalled();
+      expect(mockFacultiesService.findAll).toHaveBeenCalledWith({
+        page: 1,
+        limit: 10,
+      });
     });
   });
 

--- a/apps/api/src/faculties/faculties.controller.ts
+++ b/apps/api/src/faculties/faculties.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
@@ -18,6 +19,7 @@ import { CreateFacultyDto } from "./dto/create-faculty.dto";
 import { UpdateFacultyDto } from "./dto/update-faculty.dto";
 import { Faculty } from "./entities/faculty.entity";
 import { FacultiesService } from "./faculties.service";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("faculties")
@@ -27,8 +29,8 @@ export class FacultiesController {
   @ApiOperation({ summary: "Get all faculties" })
   @ApiResponse({ status: 200, description: "List of faculties returned." })
   @Get()
-  findAll(): Promise<Faculty[]> {
-    return this.facultiesService.findAll();
+  findAll(@Query() pagination: PaginationDto): Promise<Faculty[]> {
+    return this.facultiesService.findAll(pagination);
   }
 
   @ApiOperation({ summary: "Get faculty by UUID" })

--- a/apps/api/src/faculties/faculties.controller.ts
+++ b/apps/api/src/faculties/faculties.controller.ts
@@ -15,11 +15,11 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
 import { JwtAuthGuard } from "@/auth/guards/jwt-auth.guard";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { CreateFacultyDto } from "./dto/create-faculty.dto";
 import { UpdateFacultyDto } from "./dto/update-faculty.dto";
 import { Faculty } from "./entities/faculty.entity";
 import { FacultiesService } from "./faculties.service";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("faculties")

--- a/apps/api/src/faculties/faculties.service.spec.ts
+++ b/apps/api/src/faculties/faculties.service.spec.ts
@@ -82,6 +82,7 @@ describe("FacultiesService", () => {
         relations: ["courses"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/faculties/faculties.service.spec.ts
+++ b/apps/api/src/faculties/faculties.service.spec.ts
@@ -29,7 +29,7 @@ describe("FacultiesService", () => {
   const mockFacultyRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneBy: jest.fn(),
     merge: jest.fn(),
@@ -70,13 +70,18 @@ describe("FacultiesService", () => {
   describe("findAll", () => {
     it("should return an array of faculties", async () => {
       const faculties = [mockFaculty];
-      mockFacultyRepository.find.mockResolvedValue(faculties);
+      mockFacultyRepository.findAndCount.mockResolvedValue([
+        faculties,
+        faculties.length,
+      ]);
 
-      const result = await service.findAll();
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(faculties);
-      expect(mockFacultyRepository.find).toHaveBeenCalledWith({
+      expect(mockFacultyRepository.findAndCount).toHaveBeenCalledWith({
         relations: ["courses"],
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/faculties/faculties.service.ts
+++ b/apps/api/src/faculties/faculties.service.ts
@@ -1,12 +1,12 @@
 import { Injectable } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { validateAndGetRelations } from "@/common/utils/entity-relation.utils";
 import { Course } from "@/courses/entities/course.entity";
 import { CreateFacultyDto } from "./dto/create-faculty.dto";
 import { UpdateFacultyDto } from "./dto/update-faculty.dto";
 import { Faculty } from "./entities/faculty.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class FacultiesService {
@@ -36,10 +36,10 @@ export class FacultiesService {
     const { page, limit } = pagination;
 
     const [items] = await this.facultyRepository.findAndCount({
-       relations: ["courses"],
-       skip: (page - 1) * limit,
-       take: limit, 
-      });
+      relations: ["courses"],
+      skip: (page - 1) * limit,
+      take: limit,
+    });
 
     return items;
   }

--- a/apps/api/src/faculties/faculties.service.ts
+++ b/apps/api/src/faculties/faculties.service.ts
@@ -6,6 +6,7 @@ import { Course } from "@/courses/entities/course.entity";
 import { CreateFacultyDto } from "./dto/create-faculty.dto";
 import { UpdateFacultyDto } from "./dto/update-faculty.dto";
 import { Faculty } from "./entities/faculty.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class FacultiesService {
@@ -31,8 +32,16 @@ export class FacultiesService {
     return this.facultyRepository.save(faculty);
   }
 
-  findAll(): Promise<Faculty[]> {
-    return this.facultyRepository.find({ relations: ["courses"] });
+  async findAll(pagination: PaginationDto): Promise<Faculty[]> {
+    const { page, limit } = pagination;
+
+    const [items] = await this.facultyRepository.findAndCount({
+       relations: ["courses"],
+       skip: (page - 1) * limit,
+       take: limit, 
+      });
+
+    return items;
   }
 
   findOne(id: string): Promise<Faculty> {

--- a/apps/api/src/faculties/faculties.service.ts
+++ b/apps/api/src/faculties/faculties.service.ts
@@ -39,6 +39,7 @@ export class FacultiesService {
       relations: ["courses"],
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/main.ts
+++ b/apps/api/src/main.ts
@@ -13,6 +13,7 @@ async function bootstrap() {
     new ValidationPipe({
       whitelist: true,
       forbidNonWhitelisted: true,
+      transform: true,
     }),
   );
   app.useGlobalFilters(new EntityNotFoundFilter());

--- a/apps/api/src/requests/dto/request-filter.dto.spec.ts
+++ b/apps/api/src/requests/dto/request-filter.dto.spec.ts
@@ -30,4 +30,51 @@ describe("RequestFilterDto transformation", () => {
 
     expect(errors).toHaveLength(0);
   });
+
+  describe("sortBy / sortOrder", () => {
+    it.each([
+      "createdAt",
+      "updatedAt",
+      "reviewedAt",
+    ])("accepts %s as a valid sortBy value", async (sortBy) => {
+      const dto = plainToInstance(RequestFilterDto, { sortBy });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("rejects a sortBy value that isn't whitelisted", async () => {
+      const dto = plainToInstance(RequestFilterDto, { sortBy: "status" });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortBy")).toBe(true);
+    });
+
+    it.each([
+      "ASC",
+      "DESC",
+    ])("accepts %s as a valid sortOrder", async (sortOrder) => {
+      const dto = plainToInstance(RequestFilterDto, {
+        sortBy: "createdAt",
+        sortOrder,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("rejects an invalid sortOrder value", async () => {
+      const dto = plainToInstance(RequestFilterDto, {
+        sortBy: "createdAt",
+        sortOrder: "sideways",
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortOrder")).toBe(true);
+    });
+  });
 });

--- a/apps/api/src/requests/dto/request-filter.dto.ts
+++ b/apps/api/src/requests/dto/request-filter.dto.ts
@@ -1,4 +1,4 @@
-import { IsEnum, IsOptional, IsUUID } from "class-validator";
+import { IsEnum, IsIn, IsOptional, IsUUID } from "class-validator";
 import { PaginationDto } from "@/common/dto/pagination.dto";
 import {
   RequestAction,
@@ -26,4 +26,12 @@ export class RequestFilterDto extends PaginationDto {
   @IsOptional()
   @IsUUID()
   requestedBy?: string;
+
+  @IsOptional()
+  @IsIn(["createdAt", "updatedAt", "reviewedAt"])
+  sortBy?: string;
+
+  @IsOptional()
+  @IsIn(["ASC", "DESC"])
+  sortOrder?: "ASC" | "DESC";
 }

--- a/apps/api/src/requests/dto/request-filter.dto.ts
+++ b/apps/api/src/requests/dto/request-filter.dto.ts
@@ -4,8 +4,9 @@ import {
   RequestStatus,
   RequestType,
 } from "@/requests/entities/request.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
-export class RequestFilterDto {
+export class RequestFilterDto extends PaginationDto {
   @IsOptional()
   @IsEnum(RequestType)
   type?: RequestType;

--- a/apps/api/src/requests/dto/request-filter.dto.ts
+++ b/apps/api/src/requests/dto/request-filter.dto.ts
@@ -1,10 +1,10 @@
 import { IsEnum, IsOptional, IsUUID } from "class-validator";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import {
   RequestAction,
   RequestStatus,
   RequestType,
 } from "@/requests/entities/request.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 export class RequestFilterDto extends PaginationDto {
   @IsOptional()

--- a/apps/api/src/requests/requests.controller.spec.ts
+++ b/apps/api/src/requests/requests.controller.spec.ts
@@ -114,12 +114,12 @@ describe("RequestsController", () => {
 
       const result = await controller.findAll(
         { activeAssociationId: "3" },
-        { status: RequestStatus.PENDING },
+        { status: RequestStatus.PENDING, page: 1, limit: 10 },
       );
 
       expect(result).toEqual([mockRequest]);
       expect(mockRequestsService.findAll).toHaveBeenCalledWith(
-        { status: RequestStatus.PENDING },
+        { status: RequestStatus.PENDING, page: 1, limit: 10 },
         "3",
       );
     });
@@ -127,9 +127,12 @@ describe("RequestsController", () => {
     it("forwards undefined when the guard left no activeAssociationId (admin, no header)", async () => {
       mockRequestsService.findAll.mockResolvedValue([]);
 
-      await controller.findAll({}, {});
+      await controller.findAll({}, { page: 1, limit: 10 });
 
-      expect(mockRequestsService.findAll).toHaveBeenCalledWith({}, undefined);
+      expect(mockRequestsService.findAll).toHaveBeenCalledWith(
+        { page: 1, limit: 10 },
+        undefined,
+      );
     });
   });
 

--- a/apps/api/src/requests/requests.service.spec.ts
+++ b/apps/api/src/requests/requests.service.spec.ts
@@ -791,6 +791,7 @@ describe("RequestsService", () => {
         where: {},
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -808,6 +809,7 @@ describe("RequestsService", () => {
         where: { status: RequestStatus.PENDING },
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -827,6 +829,7 @@ describe("RequestsService", () => {
         relations,
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -853,6 +856,7 @@ describe("RequestsService", () => {
         relations,
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/requests/requests.service.spec.ts
+++ b/apps/api/src/requests/requests.service.spec.ts
@@ -80,7 +80,7 @@ describe("RequestsService", () => {
   const mockRequestRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
     merge: jest.fn(),
@@ -781,58 +781,78 @@ describe("RequestsService", () => {
     // or undefined. This describe block only covers query construction.
 
     it("without an activeAssociationId or filters returns everything", async () => {
-      mockRequestRepository.find.mockResolvedValue([mockRequest]);
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
 
-      const result = await service.findAll({});
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual([mockRequest]);
-      expect(mockRequestRepository.find).toHaveBeenCalledWith({
+      expect(mockRequestRepository.findAndCount).toHaveBeenCalledWith({
         relations,
         where: {},
+        skip: 0,
+        take: 10,
       });
     });
 
     it("a status filter narrows the where clause", async () => {
-      mockRequestRepository.find.mockResolvedValue([mockRequest]);
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
 
-      await service.findAll({ status: RequestStatus.PENDING });
+      await service.findAll({
+        status: RequestStatus.PENDING,
+        page: 1,
+        limit: 10,
+      });
 
-      expect(mockRequestRepository.find).toHaveBeenCalledWith({
+      expect(mockRequestRepository.findAndCount).toHaveBeenCalledWith({
         relations,
         where: { status: RequestStatus.PENDING },
+        skip: 0,
+        take: 10,
       });
     });
 
     it("scopes results to the given activeAssociationId", async () => {
-      mockRequestRepository.find.mockResolvedValue([mockRequest]);
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
 
-      await service.findAll({ type: RequestType.EVENT }, "3");
+      await service.findAll(
+        { type: RequestType.EVENT, page: 1, limit: 10 },
+        "3",
+      );
 
-      expect(mockRequestRepository.find).toHaveBeenCalledWith({
+      expect(mockRequestRepository.findAndCount).toHaveBeenCalledWith({
         where: {
           targetAssociation: { id: "3" },
           type: RequestType.EVENT,
         },
         relations,
+        skip: 0,
+        take: 10,
       });
     });
 
     it("combines an activeAssociationId with the other filters", async () => {
-      mockRequestRepository.find.mockResolvedValue([mockRequest]);
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
 
       const result = await service.findAll(
-        { status: RequestStatus.PENDING, requestedBy: mockUser.id },
+        {
+          status: RequestStatus.PENDING,
+          requestedBy: mockUser.id,
+          page: 1,
+          limit: 10,
+        },
         mockAssociation.id,
       );
 
       expect(result).toEqual([mockRequest]);
-      expect(mockRequestRepository.find).toHaveBeenCalledWith({
+      expect(mockRequestRepository.findAndCount).toHaveBeenCalledWith({
         where: {
           targetAssociation: { id: mockAssociation.id },
           status: RequestStatus.PENDING,
           requestedBy: { id: mockUser.id },
         },
         relations,
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/requests/requests.service.spec.ts
+++ b/apps/api/src/requests/requests.service.spec.ts
@@ -859,5 +859,32 @@ describe("RequestsService", () => {
         order: { id: "ASC" },
       });
     });
+
+    it("orders by the requested sortBy field before the id tiebreaker", async () => {
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
+
+      await service.findAll({
+        sortBy: "createdAt",
+        sortOrder: "DESC",
+        page: 1,
+        limit: 10,
+      });
+
+      const { order } = mockRequestRepository.findAndCount.mock.calls[0][0];
+      expect(order).toEqual({ createdAt: "DESC", id: "ASC" });
+      // Key order matters: TypeORM builds ORDER BY in object-key insertion
+      // order, so the requested field must come before the id tiebreaker.
+      expect(Object.keys(order)).toEqual(["createdAt", "id"]);
+    });
+
+    it("defaults sortOrder to ASC when only sortBy is provided", async () => {
+      mockRequestRepository.findAndCount.mockResolvedValue([[mockRequest], 1]);
+
+      await service.findAll({ sortBy: "createdAt", page: 1, limit: 10 });
+
+      expect(mockRequestRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ order: { createdAt: "ASC", id: "ASC" } }),
+      );
+    });
   });
 });

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -153,7 +153,7 @@ export class RequestsService {
       ...(requestedBy !== undefined && { requestedBy: { id: requestedBy } }),
     };
 
-    const [items] =  await this.requestRepository.findAndCount({
+    const [items] = await this.requestRepository.findAndCount({
       where: {
         ...(activeAssociationId !== undefined && {
           targetAssociation: { id: activeAssociationId },

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -145,7 +145,8 @@ export class RequestsService {
       targetService: true,
     };
 
-    const { type, status, requestedBy, limit, page } = filters;
+    const { type, status, requestedBy, sortBy, sortOrder, limit, page } =
+      filters;
 
     const whereFilter = {
       ...(type !== undefined && { type }),
@@ -163,7 +164,10 @@ export class RequestsService {
       relations,
       skip: (page - 1) * limit,
       take: limit,
-      order: { id: "ASC" },
+      order: {
+        ...(sortBy && { [sortBy]: sortOrder ?? "ASC" }),
+        id: "ASC",
+      },
     });
 
     return items;

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -163,6 +163,7 @@ export class RequestsService {
       relations,
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/requests/requests.service.ts
+++ b/apps/api/src/requests/requests.service.ts
@@ -145,7 +145,7 @@ export class RequestsService {
       targetService: true,
     };
 
-    const { type, status, requestedBy } = filters;
+    const { type, status, requestedBy, limit, page } = filters;
 
     const whereFilter = {
       ...(type !== undefined && { type }),
@@ -153,7 +153,7 @@ export class RequestsService {
       ...(requestedBy !== undefined && { requestedBy: { id: requestedBy } }),
     };
 
-    return this.requestRepository.find({
+    const [items] =  await this.requestRepository.findAndCount({
       where: {
         ...(activeAssociationId !== undefined && {
           targetAssociation: { id: activeAssociationId },
@@ -161,7 +161,11 @@ export class RequestsService {
         ...whereFilter,
       },
       relations,
+      skip: (page - 1) * limit,
+      take: limit,
     });
+
+    return items;
   }
 
   async approve(id: string): Promise<Event | Service> {

--- a/apps/api/src/services/dto/service-filter.dto.spec.ts
+++ b/apps/api/src/services/dto/service-filter.dto.spec.ts
@@ -81,6 +81,47 @@ describe("ServiceFilterDto", () => {
       expect(errors.some((e) => e.property === "facultyId")).toBe(true);
       expect(errors.some((e) => e.property === "courseId")).toBe(true);
     });
+
+    it("should be valid with sortBy 'name'", async () => {
+      const dto = plainToInstance(ServiceFilterDto, { sortBy: "name" });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should fail validation for a sortBy value that isn't whitelisted", async () => {
+      const dto = plainToInstance(ServiceFilterDto, { sortBy: "location" });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortBy")).toBe(true);
+    });
+
+    it.each([
+      "ASC",
+      "DESC",
+    ])("should be valid with sortOrder %s", async (sortOrder) => {
+      const dto = plainToInstance(ServiceFilterDto, {
+        sortBy: "name",
+        sortOrder,
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it("should fail validation for an invalid sortOrder value", async () => {
+      const dto = plainToInstance(ServiceFilterDto, {
+        sortBy: "name",
+        sortOrder: "sideways",
+      });
+
+      const errors = await validate(dto);
+
+      expect(errors.some((e) => e.property === "sortOrder")).toBe(true);
+    });
   });
 
   describe("Optional fields", () => {
@@ -98,6 +139,13 @@ describe("ServiceFilterDto", () => {
 
       expect(dto.facultyId).toBe(validUuid1);
       expect(dto.courseId).toBeUndefined();
+    });
+
+    it("should have undefined sortBy and sortOrder when not provided", () => {
+      const dto = plainToInstance(ServiceFilterDto, {});
+
+      expect(dto.sortBy).toBeUndefined();
+      expect(dto.sortOrder).toBeUndefined();
     });
   });
 });

--- a/apps/api/src/services/dto/service-filter.dto.ts
+++ b/apps/api/src/services/dto/service-filter.dto.ts
@@ -1,6 +1,7 @@
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { IsOptional, IsUUID } from "class-validator";
 
-export class ServiceFilterDto {
+export class ServiceFilterDto extends PaginationDto {
   /**
    * The faculty UUID to filter services by.
    * @example '123e4567-e89b-12d3-a456-426614174000'

--- a/apps/api/src/services/dto/service-filter.dto.ts
+++ b/apps/api/src/services/dto/service-filter.dto.ts
@@ -1,5 +1,5 @@
-import { PaginationDto } from "@/common/dto/pagination.dto";
 import { IsOptional, IsUUID } from "class-validator";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 export class ServiceFilterDto extends PaginationDto {
   /**

--- a/apps/api/src/services/dto/service-filter.dto.ts
+++ b/apps/api/src/services/dto/service-filter.dto.ts
@@ -1,4 +1,4 @@
-import { IsOptional, IsUUID } from "class-validator";
+import { IsIn, IsOptional, IsUUID } from "class-validator";
 import { PaginationDto } from "@/common/dto/pagination.dto";
 
 export class ServiceFilterDto extends PaginationDto {
@@ -17,4 +17,12 @@ export class ServiceFilterDto extends PaginationDto {
   @IsOptional()
   @IsUUID()
   courseId?: string;
+
+  @IsOptional()
+  @IsIn(["name"])
+  sortBy?: string;
+
+  @IsOptional()
+  @IsIn(["ASC", "DESC"])
+  sortOrder?: "ASC" | "DESC";
 }

--- a/apps/api/src/services/services.controller.spec.ts
+++ b/apps/api/src/services/services.controller.spec.ts
@@ -78,8 +78,8 @@ describe("ServicesController", () => {
 
     it("findAll should call service.findAll and return its value", async () => {
       mockService.findAll.mockResolvedValue([svc]);
-      const res = await controller.findAll({});
-      expect(mockService.findAll).toHaveBeenCalledWith({});
+      const res = await controller.findAll({ page: 1, limit: 10 });
+      expect(mockService.findAll).toHaveBeenCalledWith({ page: 1, limit: 10 });
       expect(res).toEqual([svc]);
     });
 

--- a/apps/api/src/services/services.service.spec.ts
+++ b/apps/api/src/services/services.service.spec.ts
@@ -225,6 +225,41 @@ describe("ServicesService", () => {
         order: { id: "ASC" },
       });
     });
+
+    it("orders by the requested sortBy field before the id tiebreaker", async () => {
+      const services = [mockService];
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
+
+      await service.findAll({
+        sortBy: "name",
+        sortOrder: "DESC",
+        page: 1,
+        limit: 10,
+      });
+
+      const { order } = mockServiceRepository.findAndCount.mock.calls[0][0];
+      expect(order).toEqual({ name: "DESC", id: "ASC" });
+      // Key order matters: TypeORM builds ORDER BY in object-key insertion
+      // order, so the requested field must come before the id tiebreaker.
+      expect(Object.keys(order)).toEqual(["name", "id"]);
+    });
+
+    it("defaults sortOrder to ASC when only sortBy is provided", async () => {
+      const services = [mockService];
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
+
+      await service.findAll({ sortBy: "name", page: 1, limit: 10 });
+
+      expect(mockServiceRepository.findAndCount).toHaveBeenCalledWith(
+        expect.objectContaining({ order: { name: "ASC", id: "ASC" } }),
+      );
+    });
   });
 
   describe("findOne", () => {

--- a/apps/api/src/services/services.service.spec.ts
+++ b/apps/api/src/services/services.service.spec.ts
@@ -66,7 +66,7 @@ describe("ServicesService", () => {
   const mockServiceRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOne: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
@@ -132,60 +132,93 @@ describe("ServicesService", () => {
   describe("findAll", () => {
     it("should return an array of services", async () => {
       const services = [mockService];
-      mockServiceRepository.find.mockResolvedValue(services);
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
 
-      const result = await service.findAll({});
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(services);
-      expect(mockServiceRepository.find).toHaveBeenCalledWith({
+      expect(mockServiceRepository.findAndCount).toHaveBeenCalledWith({
         where: {},
         relations: ["schedule", "faculty", "course", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should filter by facultyId", async () => {
       const services = [mockService];
-      mockServiceRepository.find.mockResolvedValue(services);
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
 
-      const result = await service.findAll({ facultyId: "1" });
+      const result = await service.findAll({
+        facultyId: "1",
+        page: 1,
+        limit: 10,
+      });
 
       expect(result).toEqual(services);
-      expect(mockServiceRepository.find).toHaveBeenCalledWith({
+      expect(mockServiceRepository.findAndCount).toHaveBeenCalledWith({
         where: {
           faculty: { id: "1" },
         },
         relations: ["schedule", "faculty", "course", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should filter by courseId", async () => {
       const services = [mockService];
-      mockServiceRepository.find.mockResolvedValue(services);
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
 
-      const result = await service.findAll({ courseId: "2" });
+      const result = await service.findAll({
+        courseId: "2",
+        page: 1,
+        limit: 10,
+      });
 
       expect(result).toEqual(services);
-      expect(mockServiceRepository.find).toHaveBeenCalledWith({
+      expect(mockServiceRepository.findAndCount).toHaveBeenCalledWith({
         where: {
           course: { id: "2" },
         },
         relations: ["schedule", "faculty", "course", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
 
     it("should filter by both facultyId and courseId", async () => {
       const services = [mockService];
-      mockServiceRepository.find.mockResolvedValue(services);
+      mockServiceRepository.findAndCount.mockResolvedValue([
+        services,
+        services.length,
+      ]);
 
-      const result = await service.findAll({ facultyId: "1", courseId: "2" });
+      const result = await service.findAll({
+        facultyId: "1",
+        courseId: "2",
+        page: 1,
+        limit: 10,
+      });
 
       expect(result).toEqual(services);
-      expect(mockServiceRepository.find).toHaveBeenCalledWith({
+      expect(mockServiceRepository.findAndCount).toHaveBeenCalledWith({
         where: {
           faculty: { id: "1" },
           course: { id: "2" },
         },
         relations: ["schedule", "faculty", "course", "createdBy"],
+        skip: 0,
+        take: 10,
       });
     });
   });

--- a/apps/api/src/services/services.service.spec.ts
+++ b/apps/api/src/services/services.service.spec.ts
@@ -145,6 +145,7 @@ describe("ServicesService", () => {
         relations: ["schedule", "faculty", "course", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -169,6 +170,7 @@ describe("ServicesService", () => {
         relations: ["schedule", "faculty", "course", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -193,6 +195,7 @@ describe("ServicesService", () => {
         relations: ["schedule", "faculty", "course", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
 
@@ -219,6 +222,7 @@ describe("ServicesService", () => {
         relations: ["schedule", "faculty", "course", "createdBy"],
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/services/services.service.ts
+++ b/apps/api/src/services/services.service.ts
@@ -135,6 +135,7 @@ export class ServicesService
       relations: ["schedule", "faculty", "course", "createdBy"],
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/services/services.service.ts
+++ b/apps/api/src/services/services.service.ts
@@ -125,7 +125,7 @@ export class ServicesService
   }
 
   async findAll(filters: ServiceFilterDto): Promise<Service[]> {
-    const { facultyId, courseId, limit, page } = filters;
+    const { facultyId, courseId, sortBy, sortOrder, limit, page } = filters;
 
     const [items] = await this.serviceRepository.findAndCount({
       where: {
@@ -135,7 +135,10 @@ export class ServicesService
       relations: ["schedule", "faculty", "course", "createdBy"],
       skip: (page - 1) * limit,
       take: limit,
-      order: { id: "ASC" },
+      order: {
+        ...(sortBy && { [sortBy]: sortOrder ?? "ASC" }),
+        id: "ASC",
+      },
     });
 
     return items;

--- a/apps/api/src/services/services.service.ts
+++ b/apps/api/src/services/services.service.ts
@@ -124,16 +124,20 @@ export class ServicesService
     return this.update(id, payload);
   }
 
-  findAll(filters: ServiceFilterDto): Promise<Service[]> {
-    const { facultyId, courseId } = filters;
+  async findAll(filters: ServiceFilterDto): Promise<Service[]> {
+    const { facultyId, courseId, limit, page } = filters;
 
-    return this.serviceRepository.find({
+    const [items] = await this.serviceRepository.findAndCount({
       where: {
         ...(facultyId && { faculty: { id: facultyId } }),
         ...(courseId && { course: { id: courseId } }),
       },
       relations: ["schedule", "faculty", "course", "createdBy"],
+      skip: (page - 1) * limit,
+      take: limit,
     });
+
+    return items;
   }
 
   async findOne(id: string): Promise<Service> {

--- a/apps/api/src/users/users.controller.spec.ts
+++ b/apps/api/src/users/users.controller.spec.ts
@@ -70,10 +70,13 @@ describe("UsersController", () => {
       const users = [mockUser];
       mockUsersService.findAll.mockResolvedValue(users);
 
-      const result = await controller.findAll();
+      const result = await controller.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(users);
-      expect(mockUsersService.findAll).toHaveBeenCalled();
+      expect(mockUsersService.findAll).toHaveBeenCalledWith({
+        page: 1,
+        limit: 10,
+      });
     });
   });
 

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -8,6 +8,7 @@ import {
   ParseUUIDPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
   UseInterceptors,
 } from "@nestjs/common";
@@ -18,6 +19,7 @@ import { CreateUserDto } from "@/users/dto/create-user.dto";
 import { UpdateUserDto } from "@/users/dto/update-user.dto";
 import { User } from "./entities/user.entity";
 import { UsersService } from "./users.service";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("users")
@@ -27,8 +29,8 @@ export class UsersController {
   @Get()
   @ApiOperation({ summary: "Get all users" })
   @ApiResponse({ status: 200, description: "List of users returned." })
-  findAll(): Promise<User[]> {
-    return this.usersService.findAll();
+  findAll(@Query() pagination: PaginationDto): Promise<User[]> {
+    return this.usersService.findAll(pagination);
   }
 
   @ApiBearerAuth("access-token")

--- a/apps/api/src/users/users.controller.ts
+++ b/apps/api/src/users/users.controller.ts
@@ -15,11 +15,11 @@ import {
 import { ApiBearerAuth, ApiOperation, ApiResponse } from "@nestjs/swagger";
 import { AdminOnlyGuard } from "@/auth/guards/admin-only.guard";
 import { JwtAuthGuard } from "@/auth/guards/jwt-auth.guard";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { CreateUserDto } from "@/users/dto/create-user.dto";
 import { UpdateUserDto } from "@/users/dto/update-user.dto";
 import { User } from "./entities/user.entity";
 import { UsersService } from "./users.service";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @UseInterceptors(ClassSerializerInterceptor)
 @Controller("users")

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -26,7 +26,7 @@ describe("UsersService", () => {
   const mockUserRepository = {
     create: jest.fn(),
     save: jest.fn(),
-    find: jest.fn(),
+    findAndCount: jest.fn(),
     findOne: jest.fn(),
     findOneOrFail: jest.fn(),
     findOneByOrFail: jest.fn(),
@@ -222,12 +222,15 @@ describe("UsersService", () => {
   describe("findAll", () => {
     it("should return an array of users", async () => {
       const users = [mockUser];
-      mockUserRepository.find.mockResolvedValue(users);
+      mockUserRepository.findAndCount.mockResolvedValue([users, users.length]);
 
-      const result = await service.findAll();
+      const result = await service.findAll({ page: 1, limit: 10 });
 
       expect(result).toEqual(users);
-      expect(mockUserRepository.find).toHaveBeenCalled();
+      expect(mockUserRepository.findAndCount).toHaveBeenCalledWith({
+        skip: 0,
+        take: 10,
+      });
     });
   });
 

--- a/apps/api/src/users/users.service.spec.ts
+++ b/apps/api/src/users/users.service.spec.ts
@@ -230,6 +230,7 @@ describe("UsersService", () => {
       expect(mockUserRepository.findAndCount).toHaveBeenCalledWith({
         skip: 0,
         take: 10,
+        order: { id: "ASC" },
       });
     });
   });

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -75,6 +75,7 @@ export class UsersService implements OnApplicationBootstrap {
     const [items] = await this.userRepository.findAndCount({
       skip: (page - 1) * limit,
       take: limit,
+      order: { id: "ASC" },
     });
 
     return items;

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -4,11 +4,11 @@ import { InjectRepository } from "@nestjs/typeorm";
 import * as bcrypt from "bcrypt";
 import { Repository } from "typeorm";
 import { Association } from "@/associations/entities/association.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 import { validateAndGetRelations } from "@/common/utils/entity-relation.utils";
 import { UpdateUserDto } from "@/users/dto/update-user.dto";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { User } from "./entities/user.entity";
-import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class UsersService implements OnApplicationBootstrap {

--- a/apps/api/src/users/users.service.ts
+++ b/apps/api/src/users/users.service.ts
@@ -8,6 +8,7 @@ import { validateAndGetRelations } from "@/common/utils/entity-relation.utils";
 import { UpdateUserDto } from "@/users/dto/update-user.dto";
 import { CreateUserDto } from "./dto/create-user.dto";
 import { User } from "./entities/user.entity";
+import { PaginationDto } from "@/common/dto/pagination.dto";
 
 @Injectable()
 export class UsersService implements OnApplicationBootstrap {
@@ -68,8 +69,15 @@ export class UsersService implements OnApplicationBootstrap {
     return this.userRepository.save(user);
   }
 
-  findAll(): Promise<User[]> {
-    return this.userRepository.find();
+  async findAll(pagination: PaginationDto): Promise<User[]> {
+    const { page, limit } = pagination;
+
+    const [items] = await this.userRepository.findAndCount({
+      skip: (page - 1) * limit,
+      take: limit,
+    });
+
+    return items;
   }
 
   findOne(id: string): Promise<User> {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added pagination to association, course, event, faculty, request, service, and user listings.
  - Results can be requested by page with configurable page sizes.
  - Pagination defaults to page 1 with 10 items per page, with a maximum of 100 items.
  - Numeric pagination values are validated, transformed automatically, and invalid values are rejected.
- **Bug Fixes**
  - Database connections now default to port 5432 when no port is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->