### PR TITLE
fix: Catch duplication user creation error with a personalized message

### DIFF
--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -10,6 +10,7 @@ import { DatabaseModule } from "./database/database.module";
 import { EventsModule } from "./events/events.module";
 import { FacultiesModule } from "./faculties/faculties.module";
 import { EntityNotFoundFilter } from "./filters/entity-not-found.filter";
+import { QueryFailedErrorFilter } from "./filters/query-failed-error.filter";
 import { RequestsModule } from "./requests/requests.module";
 import { ServicesModule } from "./services/services.module";
 import { UsersModule } from "./users/users.module";
@@ -32,10 +33,9 @@ import { UsersModule } from "./users/users.module";
   ],
   controllers: [AppController],
   providers: [
-    // Sentry's filter must be registered first so it sees exceptions before
-    // any narrower filter (like EntityNotFoundFilter) fully handles them.
     { provide: APP_FILTER, useClass: SentryGlobalFilter },
     { provide: APP_FILTER, useClass: EntityNotFoundFilter },
+    { provide: APP_FILTER, useClass: QueryFailedErrorFilter },
   ],
 })
 export class AppModule {}

--- a/apps/api/src/filters/query-failed-error.filter.spec.ts
+++ b/apps/api/src/filters/query-failed-error.filter.spec.ts
@@ -1,0 +1,91 @@
+import { ArgumentsHost, HttpStatus } from "@nestjs/common";
+import { Response } from "express";
+import { QueryFailedError } from "typeorm";
+import { QueryFailedErrorFilter } from "./query-failed-error.filter";
+
+describe("QueryFailedErrorFilter", () => {
+  let filter: QueryFailedErrorFilter;
+  let mockArgumentsHost: Partial<ArgumentsHost>;
+  let mockResponse: Partial<Response> & {
+    status: jest.Mock;
+    json: jest.Mock;
+  };
+
+  beforeEach(() => {
+    filter = new QueryFailedErrorFilter();
+    mockResponse = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    mockArgumentsHost = {
+      switchToHttp: jest.fn().mockReturnValue({
+        getResponse: jest.fn().mockReturnValue(mockResponse),
+      }),
+    };
+  });
+
+  it("should be defined", () => {
+    expect(filter).toBeDefined();
+  });
+
+  it("should return 409 when the driver error is a unique violation (23505)", () => {
+    const exception = new QueryFailedError(
+      "INSERT INTO ...",
+      undefined,
+      Object.assign(new Error("duplicate key value"), {
+        code: "23505",
+        detail: "Key (email)=(admin@example.com) already exists.",
+      }),
+    );
+
+    filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: "There is already a user registered with this email address",
+      error: "Conflict",
+    });
+  });
+
+  it("should return 500 for a non-unique-violation driver error code", () => {
+    const exception = new QueryFailedError(
+      "INSERT INTO ...",
+      undefined,
+      Object.assign(new Error("not-null constraint"), {
+        code: "23502",
+        detail: "null value in column violates not-null constraint",
+      }),
+    );
+
+    filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: "Internal server error",
+      error: "Internal Server Error",
+    });
+  });
+
+  it("should return 500 when there is no driver error code at all", () => {
+    const exception = new QueryFailedError(
+      "INSERT INTO ...",
+      undefined,
+      new Error("unknown error"),
+    );
+
+    filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+    expect(mockResponse.status).toHaveBeenCalledWith(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+    );
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: "Internal server error",
+      error: "Internal Server Error",
+    });
+  });
+});

--- a/apps/api/src/filters/query-failed-error.filter.spec.ts
+++ b/apps/api/src/filters/query-failed-error.filter.spec.ts
@@ -28,7 +28,7 @@ describe("QueryFailedErrorFilter", () => {
     expect(filter).toBeDefined();
   });
 
-  it("should return 409 when the driver error is a unique violation (23505)", () => {
+  it("should return 409 naming the violated field for a unique violation (23505)", () => {
     const exception = new QueryFailedError(
       "INSERT INTO ...",
       undefined,
@@ -43,7 +43,45 @@ describe("QueryFailedErrorFilter", () => {
     expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.CONFLICT);
     expect(mockResponse.json).toHaveBeenCalledWith({
       statusCode: HttpStatus.CONFLICT,
-      message: "There is already a user registered with this email address",
+      message: "A record with this email already exists",
+      error: "Conflict",
+    });
+  });
+
+  it("should name whichever field violated the constraint, not just email", () => {
+    const exception = new QueryFailedError(
+      "INSERT INTO ...",
+      undefined,
+      Object.assign(new Error("duplicate key value"), {
+        code: "23505",
+        detail: "Key (acronym)=(CC) already exists.",
+      }),
+    );
+
+    filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: "A record with this acronym already exists",
+      error: "Conflict",
+    });
+  });
+
+  it('should fall back to "value" when the detail message has no parseable field', () => {
+    const exception = new QueryFailedError(
+      "INSERT INTO ...",
+      undefined,
+      Object.assign(new Error("duplicate key value"), {
+        code: "23505",
+        detail: undefined,
+      }),
+    );
+
+    filter.catch(exception, mockArgumentsHost as ArgumentsHost);
+
+    expect(mockResponse.json).toHaveBeenCalledWith({
+      statusCode: HttpStatus.CONFLICT,
+      message: "A record with this value already exists",
       error: "Conflict",
     });
   });

--- a/apps/api/src/filters/query-failed-error.filter.ts
+++ b/apps/api/src/filters/query-failed-error.filter.ts
@@ -1,0 +1,36 @@
+import {
+  ArgumentsHost,
+  Catch,
+  ExceptionFilter,
+  HttpStatus,
+} from "@nestjs/common";
+import { Response } from "express";
+import { QueryFailedError } from "typeorm";
+
+@Catch(QueryFailedError)
+export class QueryFailedErrorFilter implements ExceptionFilter {
+  catch(exception: QueryFailedError, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    const driverError = exception.driverError as {
+      code?: string;
+      detail?: string;
+    };
+
+    if (driverError?.code === "23505") {
+      response.status(HttpStatus.CONFLICT).json({
+        statusCode: HttpStatus.CONFLICT,
+        message: "There is already a user registered with this email address",
+        error: "Conflict",
+      });
+      return;
+    }
+
+    response.status(HttpStatus.INTERNAL_SERVER_ERROR).json({
+      statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: "Internal server error",
+      error: "Internal Server Error",
+    });
+  }
+}

--- a/apps/api/src/filters/query-failed-error.filter.ts
+++ b/apps/api/src/filters/query-failed-error.filter.ts
@@ -19,9 +19,12 @@ export class QueryFailedErrorFilter implements ExceptionFilter {
     };
 
     if (driverError?.code === "23505") {
+      const fieldMatch = driverError.detail?.match(/^Key \(([^)]+)\)=/);
+      const field = fieldMatch ? fieldMatch[1] : "value";
+
       response.status(HttpStatus.CONFLICT).json({
         statusCode: HttpStatus.CONFLICT,
-        message: "There is already a user registered with this email address",
+        message: `A record with this ${field} already exists`,
         error: "Conflict",
       });
       return;


### PR DESCRIPTION
Previously the app would not catch the `QueryFailedError` given by TypeORM when a duplicated user (same email) was being created, meaning that the api would return a 500 `InternalServerError` cause by the default Nest global Exception filter.

To solve this instead of creating a service side verification we created a new filter `QueryFailedErrorFilter`that when a `QueryFailedError` is thrown catches it, checks if it is the `23505` status code (The error caused by the duplication of a unique identifier) and makes the response message a personalized one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved database error handling for duplicate records.
  * Duplicate-value conflicts now return a clear 409 error identifying the affected field.
  * Unrecognized database errors continue to return a generic server error response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->